### PR TITLE
Heartbeat Signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+0.10.0 | 2018-06-04
+---
+
+ * moves `faktory-client` into this repo
+ * `require('faktory-worker/client')` export now available
+ * manager now respects faktory-server heartbeat signals (quiet, terminate) so buttons clicked in the UI will now quiet and terminate the faktory work process
+
+0.9.2 | 2018-06-04
+---
+
+ * fix incorrectly pathed faktory-work bin in package.json
+
+0.9.1 | 2018-03-30
+---
+
+ * Fixed issues where job payload attributes assumed to be defaulted by the faktory server were not being sent by the client. [The server does not default these](https://gitter.im/contribsys/faktory?at=5abe55f32b9dfdbc3a3bbafc) so now faktory-client defaults these values.
+
+0.9.0 | 2018-03-28
+---
+
+ * adds `faktory.use` to add middleware to the job execution stack (koa.js style)
+
+0.8.1 | 2018-03-26
+---
+
+ * bugfix: process.exit after graceful shutdown of manager
+
 0.8.0 | 2018-03-24
 ---
 
@@ -98,3 +125,42 @@
  * Tests for manager.js
  * add ava for tests, nyc for coverage
 
+## `faktory-client` (moved to this repo)
+
+0.6.0 | 2018-03-24
+---
+
+ * connection URL is now parsed by the [node URL module](https://nodejs.org/api/url.html#url_the_whatwg_url_api). The previous URL parsing did not allow protocols hints (tls) or passwords in the url. Because the URL lib is now used, a connection string without a protocol cannot be used. `localhost:7419` and the like will not work—please use `tcp://localhost:7419`
+
+0.5.0 | 2018-02-04
+---
+
+ * Refactor connection process: reconnect on close if not initial connection attempt
+ * Improve debug logging output
+ * Use assert module for response expectations
+ * Parse connection URLs better (allow tcp://)
+
+0.4.3 | 2017-11-12
+---
+
+ * Bugfix: in the rare case a response is dropped from the server, the code was using a variable that was not defined to log the dropped message.
+
+0.4.2 | 2017-11-12
+---
+
+ * Bugfix: server now sends NULL for fetch requests when queues are empty. The code attempted to use string methods on this, expecting that it was a buffer/string.
+
+0.4.1 | 2017-11-12
+---
+
+ * Test updates
+
+0.4.0 | 2017-11-12
+---
+
+ * Updates for faktory protocol verison 2 compatibility https://github.com/contribsys/faktory/pull/72
+
+### Breaking
+
+ * Must provide `wid` in construction if the client is going to heartbeat, otherwise it will error.
+ * .beat() now returns a string with either 'OK' or the `state` value 'quiet'|'terminate'

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -102,14 +102,16 @@ module.exports = class Manager {
 
   async beat() {
     const response = await this.pool.use(client => client.beat());
-    console.log(response);
-    switch(response) {
+    switch (response) {
       case 'quiet':
         this.quiet();
-      break;
+        break;
       case 'terminate':
         this.stop();
-      break;
+        break;
+      default:
+        // noop
+        break;
     }
   }
 

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -18,6 +18,7 @@ module.exports = class Manager {
     this.wid = opts.wid;
     this.pool = Manager.createPool(opts, this.concurrency + 2);
     this.heartbeatInterval = opts.heartbeatInterval;
+    this.beat = this.beat.bind(this);
 
     debug('starting %i worker(s)', this.concurrency);
 
@@ -79,9 +80,9 @@ module.exports = class Manager {
 
     const cleanup = async () => {
       debug('cleaning up');
-      clearInterval(this.heartbeat);
       await this.pool.drain();
       this.pool.clear();
+      clearInterval(this.heartbeat);
     };
 
     const forceShutdown = setTimeout(() => {
@@ -99,12 +100,21 @@ module.exports = class Manager {
     return this.processors.filter(p => p.working);
   }
 
-  static beat(client) {
-    return client.beat();
+  async beat() {
+    const response = await this.pool.use(client => client.beat());
+    console.log(response);
+    switch(response) {
+      case 'quiet':
+        this.quiet();
+      break;
+      case 'terminate':
+        this.stop();
+      break;
+    }
   }
 
   async run() {
-    await this.pool.use(Manager.beat);
+    await this.beat();
     this.startHeartbeat();
     this.trapSignals();
     this.processors.map(p => p.start());
@@ -112,10 +122,7 @@ module.exports = class Manager {
   }
 
   startHeartbeat() {
-    this.heartbeat = setInterval(
-      () => this.pool.use(Manager.beat),
-      this.heartbeatInterval
-    );
+    this.heartbeat = setInterval(this.beat, this.heartbeatInterval);
     return this;
   }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "ava": {
     "verbose": true,
-    "timeout": "2s"
+    "timeout": "5s"
   },
   "engines": {
     "node": ">=7"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "ava": {
     "verbose": true,
-    "timeout": "10s"
+    "timeout": "2s"
   },
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Purpose

quiet/stop based on beat response from server

when server responds with "state: quiet" or "state: terminate", the
manager should quiet or terminate as instructed. These states are
changed via the faktory-server UI.

https://github.com/contribsys/faktory/blob/bde16e33fadc7e8e8e92f67929bbf11fd7d08a8a/server/commands.go#L154-L175


### Approach

Parse response from heartbeat signal. If response is `response.state == 'quiet'`, `.quiet()` the faktory worker. If response is `response state == 'terminate'`, `.stop()` the faktory worker.

