### PR TITLE
add ctx to job thunk signature

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
-const Client = require('./lib/client');
-const Manager = require('./lib/manager');
 const debug = require('debug')('faktory-worker');
 const assert = require('assert');
+const Client = require('./lib/client');
+const Manager = require('./lib/manager');
 
 const faktory = () => {
   const middleware = [];
   const registry = {};
+  let manager;
 
   return {
     get registry() {
@@ -29,8 +30,15 @@ const faktory = () => {
       return new Client(...args).connect();
     },
     work(options = {}) {
-      const manager = new Manager(Object.assign({}, options, { registry, middleware }));
+      if (!manager) {
+        manager = new Manager(Object.assign({}, options, { registry, middleware }));
+      }
       return manager.run();
+    },
+    stop() {
+      const temp = manager;
+      manager = undefined;
+      return temp.stop();
     }
   };
 };

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -33,16 +33,16 @@ module.exports = class Processor {
 
   createHandler(middleware) {
     const execute = async (ctx, next) => {
-      const { registry, job } = ctx;
-      const fn = registry[job.jobtype];
+      const { registry, job: { jobtype, args } } = ctx;
+      const fn = registry[jobtype];
 
-      if (!fn) throw new Error(`No jobtype registered: ${job.jobtype}`);
+      if (!fn) throw new Error(`No jobtype registered: ${jobtype}`);
 
-      const thunk = await fn(...job.args);
-      if (typeof thunk === 'function') {
-        await thunk(job);
+      const thunkOrPromise = await fn(...args);
+      if (typeof thunkOrPromise === 'function') {
+        await thunkOrPromise(ctx);
       } else {
-        await thunk;
+        await thunkOrPromise;
       }
       return next();
     };

--- a/test/_helper.js
+++ b/test/_helper.js
@@ -48,7 +48,7 @@ const mockServer = () => {
 const mocked = async (fn) => {
   const server = mockServer();
   i += 1;
-  const port = 7000 + i;
+  const port = Math.ceil(7000 + i + Math.random());
   server.listen(port, '127.0.0.1');
   try {
     return fn(server, port);

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -1,0 +1,118 @@
+const test = require('ava');
+const {
+  withConnection,
+  sleep,
+  push,
+  mockServer
+} = require('./_helper');
+const Processor = require('../lib/processor');
+const faktoryFactory = require('../');
+
+test('invokes middleware', async t => {
+  const { queue, jobtype } = await push();
+
+  await new Promise((resolve) => {
+    const processor = new Processor({
+      withConnection,
+      queues: [queue],
+      middleware: [
+        (ctx, next) => {
+          ctx.job.args = ['hello'];
+          return next();
+        }
+      ],
+      registry: {
+        [jobtype]: (...args) => {
+          t.deepEqual(args, ['hello'], 'middleware not executed');
+          resolve();
+        }
+      }
+    });
+
+    processor.start();
+  });
+});
+
+test('invokes middleware in order', async t => {
+  const recorder = [];
+  const { queue, jobtype } = await push();
+  let processor;
+
+  await new Promise((resolve) => {
+
+    processor = new Processor({
+      withConnection,
+      queues: [queue],
+      middleware: [
+        async (ctx, next) => {
+          recorder.push('before 1');
+          await next();
+          recorder.push('after 1');
+        },
+        async (ctx, next) => {
+          recorder.push('before 2');
+          await next();
+          recorder.push('after 2');
+        }
+      ],
+      registry: {
+        [jobtype]: async (...args) => {
+          recorder.push('run 1');
+          await sleep(1);
+          recorder.push('run 2');
+          resolve();
+        }
+      }
+    });
+    processor.start();
+  });
+
+  await processor.stop();
+
+  t.deepEqual(
+    recorder,
+    [
+      'before 1',
+      'before 2',
+      'run 1',
+      'run 2',
+      'after 2',
+      'after 1'
+    ],
+    'middleware not executed in order'
+  );
+});
+
+test('.use() adds middleware to the stack', t => {
+  const instance = faktoryFactory();
+  const mmw = () => {};
+
+  instance.use(mmw);
+
+  t.is(instance.middleware[0], mmw, 'middleware function not added to .middleware');
+});
+
+test('middleware context is passed to job thunk', async t => {
+  const { queue, jobtype } = await push({args: [1]});
+  const instance = faktoryFactory();
+
+  instance.use((ctx, next) => {
+    ctx.memo = ['hello'];
+    return next();
+  });
+  instance.use((ctx, next) => {
+    ctx.memo.push('world');
+    return next();
+  });
+
+  await new Promise((resolve) => {
+    instance.register(jobtype, (...args) => ({ memo }) => {
+      t.deepEqual(args, [1], 'args not correct');
+      t.deepEqual(memo, ['hello', 'world']);
+      instance.stop();
+      resolve();
+    });
+    instance.work({queues: [queue], concurrency: 1});
+  });
+
+});

--- a/test/package-export.test.js
+++ b/test/package-export.test.js
@@ -23,15 +23,6 @@ test('.use() returns self', t => {
   t.is(faktory, returned, '`this` not returned by .use');
 });
 
-test('.use() adds middleware to the stack', t => {
-  const faktory = create();
-  const mmw = () => {};
-
-  faktory.use(mmw);
-
-  t.is(faktory.middleware[0], mmw, 'middleware function not added to .middleware');
-});
-
 test('.use() throws when arg is not a function', t => {
   const faktory = create();
 
@@ -80,26 +71,6 @@ test('.work() creates a manager, runs it and resolve the manager', async t => {
   });
 });
 
-test('middleware end to end', async t => {
-  const faktory = create();
-  const { queue, jobtype } = await push({args: [1]});
-
-  faktory.use(({ job }, next) => {
-    job.memo = ['hello'];
-    return next();
-  });
-  faktory.use(({ job }, next) => {
-    job.memo.push('world');
-    return next();
-  });
-
-  await new Promise((resolve) => {
-    faktory.register(jobtype, (...args) => (job) => {
-      t.deepEqual(args, [1], 'args not correct');
-      t.deepEqual(job.memo, ['hello', 'world']);
-      resolve();
-    });
-    faktory.work({queues: [queue], concurrency: 1});
-  });
-
+test('it exports the client', t => {
+  t.is(require('../client'), require('../lib/client'));
 });


### PR DESCRIPTION
### Purpose

Prior to this PR and when using middleware, the context object was not being passed to the job function or job thunk, thus it was completely inaccessible to the job.

A job function may return a thunk that will receive the context (`ctx`) as its first argument. This matches the function signature of middleware functions and the job function is essentially a middleware function.

```js
faktory.use((ctx, next) => {
  ctx.db = await pool.acquire();
  try {
    await next();
  } finally {
    await pool.checkIn(ctx.db);
  }
});

faktory.register('TouchRecord', (...args) => (ctx) => {
  const [ recordId ]  = args;
  // do work, use ctx.db to do a query
  const record = await ctx.db.find(recordId);
  await record.touch();
});

// ctx.job is the job payload
// ctx.job.args is available
// ctx.job.custom will hold custom data persisted to the faktory server
// ctx contains all other state managed by middleware functions
```

closes #11 