### PR TITLE
Rescue failed beat attempts and stop

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -115,7 +115,7 @@ module.exports = class Manager {
           // noop
           break;
       }
-    } catch(err) {
+    } catch (err) {
       debug(`Error while checking for heartbeat: ${err}`);
       this.stop();
     }

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -80,9 +80,10 @@ module.exports = class Manager {
 
     const cleanup = async () => {
       debug('cleaning up');
+      clearInterval(this.heartbeat);
+
       await this.pool.drain();
       this.pool.clear();
-      clearInterval(this.heartbeat);
     };
 
     const forceShutdown = setTimeout(() => {
@@ -101,17 +102,22 @@ module.exports = class Manager {
   }
 
   async beat() {
-    const response = await this.pool.use(client => client.beat());
-    switch (response) {
-      case 'quiet':
-        this.quiet();
-        break;
-      case 'terminate':
-        this.stop();
-        break;
-      default:
-        // noop
-        break;
+    try {
+      const response = await this.pool.use(client => client.beat());
+      switch (response) {
+        case 'quiet':
+          this.quiet();
+          break;
+        case 'terminate':
+          this.stop();
+          break;
+        default:
+          // noop
+          break;
+      }
+    } catch(err) {
+      debug(`Error while checking for heartbeat: ${err}`);
+      this.stop();
     }
   }
 

--- a/test/manager.test.js
+++ b/test/manager.test.js
@@ -226,6 +226,29 @@ test('stops when the heartbeat response says so', async t => {
   });
 });
 
+test('stops when the heartbeat fails', async t => {
+  t.plan(1);
+  await mocked(async (server, port) => {
+    server
+      .on('BEAT', (msg, socket) => {
+        socket.destroy()
+      });
+    const manager = create({ port, concurrency: 1 });
+
+    const originalStop = manager.stop.bind(manager);
+    const promise = new Promise((resolve) => {
+      manager.stop = () => {
+        t.pass();
+        originalStop();
+        resolve();
+      };
+    });
+
+    await manager.run();
+    await promise;
+  });
+});
+
 test.skip('sends a hearbeat on heartbeatInterval', async t => {
   const server = mockServer();
   let beats = 0;


### PR DESCRIPTION
+ Clear the heartbeat interval before trying to drain the pool

Fixes #16 two fold, by clearing the heartbeat interval before draining the pool and clearing it, and by handling socket errors when checking heartbeats.