### PR TITLE
Job Builder API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,9 @@ const faktory = require('faktory-worker');
 
 const client = await faktory.connect();
 
-const jid = await client.push({
-  jobtype: 'MyDoWorkJob',
-  args: [3, 'small']
-});
+await client.job('ResizeImage', { id: 333, size: 'thumb' }).push();
 
+// cleanup
 await client.close();
 ```
 
@@ -41,9 +39,9 @@ A job is a payload of keys and values according to [the faktory job payload spec
 ```js
 const faktory = require('faktory-worker');
 
-faktory.register('MyDoWorkJob', async (id, size) => {
-  const img = await Image.find(id);
-  await resize(img.blob, size);
+faktory.register('ResizeImage', async ({ id, size }) => {
+  const image = await Image.find(id);
+  await image.resize(size);
 });
 
 await faktory.work();

--- a/bench/push
+++ b/bench/push
@@ -12,10 +12,7 @@ const n = Number(process.argv[2] || 100000);
 
   for (var i = n; i > 0; i--) {
     pushes.push(
-      client.push({
-        jobtype: 'MyJob',
-        args: [1, 'string', 3]
-      })
+      client.job('MyJob').with(1, 'string', 3).push()
     );
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,6 +6,7 @@ const uuid = require('uuid/v4');
 const os = require('os');
 const RedisParser = require('redis-parser');
 const assert = require('assert');
+const Job = require('./job');
 
 const debug = require('debug')('faktory-worker:client');
 const serverDebug = require('debug')('faktory-worker:client:server');
@@ -69,6 +70,10 @@ class Client {
     }
 
     return hash.digest('hex');
+  }
+
+  job(jobtype, ...args) {
+    return new Job(jobtype).args(...args).client(this);
   }
 
   static encode(command) {
@@ -250,15 +255,19 @@ class Client {
    * @return {String}     the jid for the pushed job
    */
   async push(job) {
-    const jobWithDefaults = Object.assign({
+    const jobWithDefaults = Object.assign(this.jobDefaults(), job);
+    await this.send(['PUSH', jobWithDefaults], 'OK');
+    return jobWithDefaults.jid;
+  }
+
+  jobDefaults() {
+    return {
       jid: uuid(),
       queue: 'default',
       args: [],
       priority: 5,
       retry: 25,
-    }, job);
-    await this.send(['PUSH', jobWithDefaults], 'OK');
-    return jobWithDefaults.jid;
+    };
   }
 
   async flush() {

--- a/lib/job.js
+++ b/lib/job.js
@@ -1,0 +1,50 @@
+class Job {
+  constructor(jobtype) {
+    if (!jobtype) throw new Error('must provide jobtype');
+    this.payload = {
+      jobtype,
+      args: [],
+    };
+  }
+  client(client) {
+    this.client = client;
+    return this;
+  }
+  // with?
+  args(...args) {
+    this.payload.args = args;
+    return this;
+  }
+  at(time) {
+    this.payload.at = time;
+    return this;
+  }
+  retry(enable = true) {
+    this.payload.retry = enable;
+    return this;
+  }
+  custom(data) {
+    this.payload.custom = data;
+    return this;
+  }
+  reserveFor(seconds) {
+    this.payload.reserve_for = seconds;
+    return this;
+  }
+  queue(name) {
+    this.payload.queue = name;
+    return this;
+  }
+  priority(num) {
+    this.payload.priority = parseInt(num, 10);
+    return this;
+  }
+  toJSON() {
+    return Object.assign({}, this.payload);
+  }
+  push() {
+    return this.client.push(this.toJSON());
+  }
+}
+
+module.exports = Job;

--- a/test/job.test.js
+++ b/test/job.test.js
@@ -1,0 +1,88 @@
+const test = require('ava');
+const Client = require('../lib/client');
+const {
+  createClient: create,
+  queueName,
+  withConnection: connect,
+  mocked
+} = require('./_helper');
+
+test.before(async () => {
+  await connect(client => client.flush());
+});
+
+test.after.always(async () => {
+  await connect(client => client.flush());
+});
+
+test('job push sends job specification to server', async (t) => {
+  const jobAt = Date.now();
+  return mocked((server, port) => {
+    server.on('PUSH', ({ data, socket }) => {
+      socket.write("+OK\r\n");
+      const {
+        jobtype,
+        args,
+        custom,
+        priority,
+        queue,
+        at,
+        reserve_for,
+        retry
+      } = data;
+      t.is(jobtype, 'MyJob');
+      t.deepEqual(args, [ 1, 2, 3 ]);
+      t.deepEqual(custom, { locale: 'en-us' });
+      t.is(priority, 10);
+      t.is(queue, 'critical');
+      t.is(at, jobAt);
+      t.is(reserve_for, 300);
+      t.is(retry, false);
+    });
+    return connect({ port }, async (client) => {
+      await client.job('MyJob')
+        .args(1, 2, 3)
+        .custom({ locale: 'en-us' })
+        .priority(10)
+        .queue('critical')
+        .at(jobAt)
+        .reserveFor(300)
+        .retry(false)
+        .push();
+    });
+  });
+});
+
+test('job push sends retry specification to server', async (t) => {
+  const jobAt = Date.now();
+  return mocked((server, port) => {
+    server.on('PUSH', ({ data, socket }) => {
+      socket.write("+OK\r\n");
+      const { retry } = data;
+      t.is(retry, true);
+    });
+    return connect({ port }, async (client) => {
+      await client.job('MyJob').retry().push();
+    });
+  });
+});
+
+
+test('job push resolves with the jid', async (t) => {
+  const jobAt = Date.now();
+  return mocked((server, port) => {
+    server.on('PUSH', ({ data, socket }) => {
+      socket.write("+OK\r\n");
+    });
+    return connect({ port }, async (client) => {
+      const jid = await client.job('MyJob').retry().push();
+      t.truthy(/\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/.test(jid));
+    });
+  });
+});
+
+test('throws an error when no jobtype provided', t => {
+  t.throws(() => {
+    new Job();
+  });
+});

--- a/test/package-export.test.js
+++ b/test/package-export.test.js
@@ -39,7 +39,7 @@ test('.registry returns the registry object', t => {
   t.is(faktory.registry['MyJob'], myFunc, 'job not found in registry');
 });
 
-test('.connect() resolve a client', async t => {
+test('.connect() resolves a client', async t => {
   const faktory = create();
 
   const client = await faktory.connect();
@@ -47,17 +47,17 @@ test('.connect() resolve a client', async t => {
   t.is(typeof client.fetch, 'function', '.connect did not resolve object with .fetch method');
   t.truthy(client.connected, 'client not connected');
 
-  client.close();
+  await client.close();
 });
 
 test('.work() creates a worker, runs it and resolve the worker', async t => {
   t.plan(1);
   await mocked(async (server, port) => {
     server
-      .on('BEAT', (msg, socket) => {
+      .on('BEAT', ({ socket }) => {
         socket.write("+OK\r\n");
       })
-      .on('FETCH', async (msg, socket) => {
+      .on('FETCH', async ({ socket }) => {
         await sleep(10);
         socket.write("$-1\r\n");
       });

--- a/test/signals.test.js
+++ b/test/signals.test.js
@@ -17,9 +17,9 @@ test('.quiet() stops job fetching', async t => {
   await mocked(async (server, port) => {
     server
       .once('BEAT', mocked.beat())
-      .on('FETCH', (msg, socket) => {
+      .on('FETCH', (...args) => {
         fetched += 1;
-        mocked.fetch(null)(msg, socket);
+        mocked.fetch(null)(...args);
       });
 
     const worker = create({ port });

--- a/test/work.test.js
+++ b/test/work.test.js
@@ -156,8 +156,8 @@ test('.handle() FAILs and throws when no job is registered', async t => {
       server
         .on('BEAT', mocked.beat())
         .on('FETCH', mocked.fetch(job))
-        .on('FAIL', (msg) => {
-          t.truthy(/"jid":"123"/.test(msg));
+        .on('FAIL', ({ data }) => {
+          t.is(data.jid, job.jid);
           worker.stop();
           resolve();
         });
@@ -178,10 +178,9 @@ test('.handle() FAILs and throws when the job throws (sync) during execution', a
       server
         .on('BEAT', mocked.beat())
         .on('FETCH', mocked.fetch(job))
-        .on('FAIL', (msg) => {
-          const payload = JSON.parse(msg.split(/\s(.+)/)[1]);
-          t.is(payload.jid, jid);
-          t.truthy(/always fails/.test(payload.message));
+        .on('FAIL', ({ data }) => {
+          t.is(data.jid, jid);
+          t.truthy(/always fails/.test(data.message));
           worker.stop();
           resolve();
         });
@@ -208,10 +207,9 @@ test('.handle() FAILs and throws when the job rejects (async) during execution',
       server
         .on('BEAT', mocked.beat())
         .on('FETCH', mocked.fetch(job))
-        .on('FAIL', (msg) => {
-          const payload = JSON.parse(msg.split(/\s(.+)/)[1]);
-          t.is(payload.jid, jid);
-          t.truthy(/rejected promise/.test(payload.message));
+        .on('FAIL', ({ data }) => {
+          t.is(data.jid, jid);
+          t.truthy(/rejected promise/.test(data.message));
           worker.stop();
           resolve();
         });
@@ -238,10 +236,9 @@ test('.handle() FAILs when the job returns a rejected promise with no error', as
       server
         .on('BEAT', mocked.beat())
         .on('FETCH', mocked.fetch(job))
-        .on('FAIL', (msg) => {
-          const payload = JSON.parse(msg.split(/\s(.+)/)[1]);
-          t.is(payload.jid, jid);
-          t.truthy(/no error or message/.test(payload.message));
+        .on('FAIL', ({ data }) => {
+          t.is(data.jid, jid);
+          t.truthy(/no error or message/.test(data.message));
           worker.stop();
           resolve();
         });


### PR DESCRIPTION
Adds a method to the `client` to start building a job. 

The job builder has methods for all job payload attributes:

```js
const client = await faktory.connect();

await client.job('MyJob', 1, 2, 3)
  .custom({ locale: 'en-us' })
  .priority(10)
  .queue('critical')
  .at(jobAt)
  .reserveFor(300)
  .retry(false)
  .push();
```

~~Is `args` a good method name?~~
~~What should the `args` method be called?~~
~~Should there be a `perform` and `performAsync`?~~
~~Should `perform` fetch the job from the registry and execute it? Should middleware be invoked?~~