### PR TITLE
fix(worker): pass down password to client

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -55,6 +55,7 @@ class Worker {
       url: options.url,
       host: options.host,
       port: options.port,
+      password: options.password,
       poolSize: this.concurrency + 2,
       labels: options.labels || [],
     });


### PR DESCRIPTION
We are not passing the password down to the client on the worker side which causes us to see many timeouts when trying to request a resource from the pool and prevents the worker from running at all.

Current workaround is to put the password in the FAKTORY_URL and not use host/password options at all.