### PR TITLE
Handle "ReplyError: ERR Unknown worker" from faktory server

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -236,11 +236,15 @@ export class Client {
    */
   async beat(): Promise<string> {
     heartDebug("BEAT");
-    const response = await this.send(["BEAT", encode({ wid: this.wid })]);
-    if (response[0] === "{") {
-      return JSON.parse(response).state;
+    try {
+      const response = await this.send(["BEAT", encode({ wid: this.wid })]);
+      if (response[0] === "{") {
+        return JSON.parse(response).state;
+      }
+      return response;
+    } catch(error) {
+      return error;
     }
-    return response;
   }
 
   /**


### PR DESCRIPTION
Issue:
Faktory returning `ReplyError: ERR Unknown worker` is not handled in `client.ts` resulting in the below exception,
```
(node:43609) UnhandledPromiseRejectionWarning: ReplyError: ERR Unknown worker 22dded38
    at parseError (/Users/laksh/Desktop/repos/kaiju/node_modules/redis-parser/lib/parser.js:179:12)
    at parseType (/Users/laksh/Desktop/repos/kaiju/node_modules/redis-parser/lib/parser.js:302:14)
node_modules/source-map-support/source-map-support.js:495
(node:43609) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
```

Cause: 
Currently, the issue is raised in this line, [Client.ts #L239](https://github.com/jbielick/faktory_worker_node/blob/master/src/client.ts#L239)

Cause of the issue: 
- [connection.ts#L207](https://github.com/jbielick/faktory_worker_node/blob/master/src/connection.ts#L207) 
- [client.ts#L212](https://github.com/jbielick/faktory_worker_node/blob/master/src/client.ts#L212)

The unhandled error has been explained in detail in this open Issue #116 

The error was replicated and the fix was tested in a separate project with the following env:

node.js version: v12.16.2

npm/yarn version: 6.14.11

faktory-server version: 1.4.2

faktory-worker package version: 4.0.1

I would be happy to add a test here for this case in `src/__tests__/client.test.ts` @jbielick 

Let me know if this is valid!