### PR TITLE
Modify heartDebug in client.ts to log to stdout

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -12,6 +12,8 @@ import { ConnectionFactory } from "./connection-factory";
 
 const debug = makeDebug("faktory-worker:client");
 const heartDebug = makeDebug("faktory-worker:client:heart");
+// set this namespace to log via console.log (goes to stdout)
+heartDebug.log = console.log.bind(console); 
 
 const FAKTORY_PROTOCOL_VERSION = 2;
 const FAKTORY_PROVIDER = process.env.FAKTORY_PROVIDER || "FAKTORY_URL";


### PR DESCRIPTION
These heart beat messages are really not errors, so it's better to send them to stdout.   
Some logging systems might flag stderr logs as errors intead of debug messages.  