### PR TITLE
Handle errors with non-string `code` attributes

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,8 +1,8 @@
 import test from "ava";
+
 import { Client } from "../client";
 import { Job, JobPayload } from "../job";
 import { mocked, registerCleaner } from "./_helper";
-
 
 registerCleaner(test);
 

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,8 +1,8 @@
 import test from "ava";
-
 import { Client } from "../client";
 import { Job, JobPayload } from "../job";
 import { mocked, registerCleaner } from "./_helper";
+
 
 registerCleaner(test);
 
@@ -258,6 +258,28 @@ test("#fail: FAILs a job without a stack", async (t) => {
 
   const error = new Error("EHANGRY");
   delete error.stack;
+
+  t.is(await client.fail(fetched.jid, error), "OK");
+});
+
+test("#fail: FAILs a job with a non-string error code", async (t) => {
+  const client = new Client();
+  const job = client.job("test");
+  await job.push();
+
+  const fetched = await client.fetch(job.queue);
+  if (!fetched) return t.fail("job not fetched");
+
+  class CustomError extends Error {
+    public readonly code;
+
+    constructor(code: number, message: string) {
+      super(message);
+      this.code = code;
+    }
+  }
+
+  const error = new CustomError(1234 ,"ETOOMANYDIGITS");
 
   t.is(await client.fail(fetched.jid, error), "OK");
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -295,7 +295,7 @@ export class Client {
         "FAIL",
         encode({
           message: e.message,
-          errtype: (e as NodeJS.ErrnoException).code,
+          errtype: `${(e as NodeJS.ErrnoException).code}`,
           backtrace: (e.stack || "").split("\n").slice(0, 100),
           jid,
         }),


### PR DESCRIPTION
FOSSA extends the standard NodeJS Error class to have some additional metadata about what went wrong. One of those pieces of metadata is an integer error code set on the error's `code` attribute. When failing the job, the error code gets sent to Faktory in the `errtype` field. The [Faktory API](https://github.com/contribsys/faktory/blob/master/docs/protocol-specification.md#fail-command) expects this field to be a string, and sending a number results in "ERR Invalid FAIL".