### PR TITLE
Add Graceful Shutdown Hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ faktory.register("ResizeImage", async ({ id, size }) => {
   await image.resize(size);
 });
 
-faktory.work().catch(error => {
+faktory.work().catch((error) => {
   console.error(`worker failed to start: ${error}`);
   process.exit(1);
 });
@@ -88,6 +88,21 @@ faktory.work();
 ```
 
 Faktory middleware works just like [`koa`](https://github.com/koajs/koa) middleware. You can register a middleware function (async or sync) with `.use`. Middleware is called for every job that is performed. Always return a promise, `await next()`, or `return next();` to allow execution to continue down the middleware chain.
+
+### Graceful Shutdowns
+
+```js
+const faktory = require("faktory-worker");
+const dbPool = require("your-favorite-db-client");
+
+faktory.work({
+  onShutdown: async () => {
+    await dbPool.close();
+  },
+});
+```
+
+Workers expose an `onShutdown` hook, which can be used to gracefully cleanup (e.g. close database connections) on shutdown of the worker. The function will be called after any in-progress jobs at the time of shutdown finish.
 
 ### CLI
 

--- a/src/__tests__/signals.test.ts
+++ b/src/__tests__/signals.test.ts
@@ -76,6 +76,24 @@ test(".stop() allows in-progress jobs to finish", async (t) => {
   await stop();
 });
 
+test(".stop() calls onShutdown hook", async (t) => {
+  let onShutdownCalled = false;
+
+  const worker = create({
+    timeout: 250,
+    onShutdown: async () => {
+      await sleep(100);
+      onShutdownCalled = true;
+    },
+  });
+
+  worker.work();
+
+  await worker.stop();
+
+  t.truthy(onShutdownCalled);
+});
+
 test("worker exits the process after stop timeout", async (t) => {
   const { queue, jobtype } = await push();
   let exited = false;


### PR DESCRIPTION
Since the worker traps shutdown signals to the process so it can gracefully handle in-progress jobs, this makes it impossible for consumers of the library to perform any kind of graceful shutdown of their own.

This PR adds the ability for a cleanup function to be passed to the worker to be called after in-progress jobs are completed.

Let me know what you think!

