### PR TITLE
Accept worker queue list as a function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faktory-worker",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "faktory-worker",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "MIT",
       "dependencies": {
         "commander": "2.20.0",

--- a/src/__tests__/worker.test.ts
+++ b/src/__tests__/worker.test.ts
@@ -31,6 +31,15 @@ test("adds default to an empty queue array", (t) => {
   t.deepEqual(worker.queues, ["default"]);
 });
 
+test("adds default to an empty queue array returned by a function", (t) => {
+  // typescript rejects functions returning an empty array of strings,
+  // but we need this test to make sure we handle empty-array returns
+  // correctly in untyped javascript
+  const worker = new Worker({ queues: () => [] as any });
+
+  t.deepEqual(worker.queues, ["default"]);
+});
+
 test("passes the password to the client", (t) => {
   const worker = new Worker({ password: "1234" });
 

--- a/src/__tests__/worker.test.ts
+++ b/src/__tests__/worker.test.ts
@@ -5,13 +5,13 @@ import { sleep, mocked, registerCleaner } from "./_helper";
 
 registerCleaner(test);
 
-test("accepts queues as array", (t) => {
-  const worker = new Worker({ queues: ["test"] });
+test("accepts queues as a function", (t) => {
+  const worker = new Worker({ queues: () => ["q1", "q2"] });
 
   t.deepEqual(
     worker.queues,
-    ["test"],
-    "queue passed as string does not yield array"
+    ["q1", "q2"],
+    "queue passed as function still yields array"
   );
 });
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -38,7 +38,7 @@ export type WorkerOptions = {
   concurrency?: number;
   timeout?: number;
   beatInterval?: number;
-  queues?: string[] | (() => string[]);
+  queues?: string[] | (() => [string, ...string[]]);
   middleware?: Middleware[];
   registry?: Registry;
   poolSize?: number;
@@ -63,7 +63,7 @@ export class Worker extends EventEmitter {
   private concurrency: number;
   private shutdownTimeout: number;
   private beatInterval: number;
-  private readonly _queues: string[] | (() => string[]);
+  private readonly _queues: string[] | (() => [string, ...string[]]);
   readonly middleware: Middleware[];
   private readonly registry: Registry;
   private quieted: boolean | undefined;
@@ -164,7 +164,7 @@ export class Worker extends EventEmitter {
 
   get queues(): string[] {
     if (this._queues instanceof Function) {
-      return this._queues();
+      return this._queues() || ["default"];
     }
 
     return this._queues;


### PR DESCRIPTION
This allows the Faktory worker to pull from a different set of queues on each job fetch, using whatever logic the user likes.

This change supports less-strict queue ordering, e.g. having two equal-priority queues that are ordered randomly on each fetch