### PR TITLE
fix: Worker.work now unquiets.

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -151,6 +151,7 @@ export class Worker extends EventEmitter {
    */
   async work(): Promise<Worker> {
     debug("work concurrency=%i", this.concurrency);
+    this.quieted = false;
     this.execute = createExecutionChain(this.middleware, this.registry);
     await this.beat();
     this.pulse = setInterval(async () => {


### PR DESCRIPTION
The worker can be quieted by calling `quiet()`. Calling `worker.work()` should resume the worker but does not. Now it does.