### PR TITLE
Let docs for `Worker.options` mention `timeout` option

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -711,7 +711,7 @@ started per-process.
 | [options] | <code>object</code> |  |  |
 | [options.wid] | <code>String</code> | <code>uuid().slice(0, 8)</code> | the wid the worker will use |
 | [options.concurrency] | <code>Number</code> | <code>20</code> | how many jobs this worker can process at once |
-| [options.shutdownTimeout] | <code>Number</code> | <code>8</code> | the amount of time in seconds that the worker                                             may take to finish a job before exiting                                             ungracefully |
+| [options.timeout] | <code>Number</code> | <code>8</code> | the amount of time in seconds that the worker                                       may take to finish a job before exiting ungracefully |
 | [options.beatInterval] | <code>Number</code> | <code>15</code> | the amount of time in seconds between each                                             heartbeat |
 | [options.queues] | <code>Array.&lt;string&gt;</code> | <code>[&#x27;default&#x27;]</code> | the queues this worker will fetch jobs from |
 | [options.middleware] | <code>Array.&lt;function()&gt;</code> | <code>[]</code> | a set of middleware to run before performing                                               each job                                       in koa.js-style middleware execution signature |

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -79,9 +79,8 @@ export class Worker extends EventEmitter {
    * @param {object} [options]
    * @param  {String} [options.wid=uuid().slice(0, 8)]: the wid the worker will use
    * @param  {Number} [options.concurrency=20]: how many jobs this worker can process at once
-   * @param  {Number} [options.shutdownTimeout=8]: the amount of time in seconds that the worker
-   *                                             may take to finish a job before exiting
-   *                                             ungracefully
+   * @param  {Number} [options.timeout=8]: the amount of time in seconds that the worker
+   *                                       may take to finish a job before exiting ungracefully
    * @param  {Number} [options.beatInterval=15]: the amount of time in seconds between each
    *                                             heartbeat
    * @param  {string[]} [options.queues=['default']]: the queues this worker will fetch jobs from


### PR DESCRIPTION
Instead of `shutdownTimeout`, which is only used internally as a private property of `Worker`.